### PR TITLE
fix: show help on how to recover a failed commit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "husky": {
         "hooks": {
             "pre-commit": "lint-staged",
-            "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+            "commit-msg": "commitlint -E HUSKY_GIT_PARAMS || (echo \"Your commit message is not lost! Try again with: git commit --edit --file=$(git rev-parse --show-toplevel)/.git/COMMIT_EDITMSG\" && exit 1)"
         }
     },
     "lint-staged": {


### PR DESCRIPTION
Commit messages are linted, if they don't conform, the commit message is gone.
But you can recover it with a special command:

    git commit --edit --file=$(git rev-parse --show-toplevel)/.git/COMMIT_EDITMSG

Display that information if the linting fails, so that people don't have to
re-type everything that had only due to a small problem.

Closes #4.

I also verified that it works on Windows.